### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ LIExposeController acts as a container view controller, much like UINavigationCo
 4. Add expose controller to your view hierarchy: <pre><code>window.rootViewController = exposeController;</code></pre>
 5. Enjoy!
 
+<!-- MacBuildServer Install Button -->
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=Demo%2FDemo.xcodeproj&amp;target=Demo&amp;repo_url=https%3A%2F%2Fgithub.com%2Flinkedin%2FLIExposeController&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+<!-- MacBuildServer Install Button -->
+
 ### Frameworks Required
 1. UIKit
 2. Foundation


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
